### PR TITLE
Allow decimal discounts; update sidebar label

### DIFF
--- a/app/(root)/pharmacist/inventory-management/page.tsx
+++ b/app/(root)/pharmacist/inventory-management/page.tsx
@@ -113,10 +113,10 @@ export default function InventoryManagement() {
       itemType === ItemType.MEDICINE
         ? medicineSchema
         : itemType === ItemType.INJECTION
-        ? injectionSchema
-        : itemType === ItemType.SURGERY
-        ? surgeryItemSchema
-        : generalItemSchema
+          ? injectionSchema
+          : itemType === ItemType.SURGERY
+            ? surgeryItemSchema
+            : generalItemSchema
     ),
     defaultValues: {
       name: "",
@@ -288,11 +288,10 @@ export default function InventoryManagement() {
                   role="tab"
                   aria-selected={isActive}
                   onClick={() => setItemType(value)}
-                  className={`min-h-[48px] min-w-[100px] flex-1 rounded-lg border px-4 py-3 text-sm font-medium touch-manipulation transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
-                    isActive
+                  className={`min-h-[48px] min-w-[100px] flex-1 rounded-lg border px-4 py-3 text-sm font-medium touch-manipulation transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${isActive
                       ? "bg-background text-foreground shadow-sm border-border"
                       : "bg-muted/50 text-muted-foreground hover:bg-muted border-transparent"
-                  }`}
+                    }`}
                 >
                   {label}
                 </button>
@@ -401,10 +400,10 @@ export default function InventoryManagement() {
                     id="manufacturerDiscount"
                     placeholder="e.g. 10"
                     type="number"
-                    inputMode="numeric"
+                    inputMode="decimal"
                     min={0}
                     max={100}
-                    step={1}
+                    step="any"
                     className="text-lg p-4 min-h-[48px] touch-manipulation"
                     {...form.register("manufacturerDiscount")}
                   />

--- a/app/(root)/pharmacist/purchase-invoices/create/page.tsx
+++ b/app/(root)/pharmacist/purchase-invoices/create/page.tsx
@@ -229,7 +229,7 @@ export default function CreatePurchaseInvoicePage() {
                                                             type="number"
                                                             min={0}
                                                             max={100}
-                                                            step={1}
+                                                            step="any"
                                                             placeholder="e.g. 10"
                                                             value={item.discount}
                                                             onChange={(e) => handleItemChange(index, "discount", e.target.value)}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -96,7 +96,7 @@ const Sidebar = () => {
       },
       { href: "/pharmacist/sales", label: "Sales" },
       { href: "/pharmacist/sales-history", label: "Sales History" },
-      { href: "/pharmacist/history", label: "View Sales" },
+      { href: "/pharmacist/history", label: "View Sales / Refund Sales" },
       { href: "/pharmacist/reports", label: "Reports & Accounts" },
     ],
   };


### PR DESCRIPTION
Allow decimal percentage values for discounts by changing number inputs to step="any" (app/(root)/pharmacist/purchase-invoices/create/page.tsx and app/(root)/pharmacist/inventory-management/page.tsx) and set inputMode="decimal" for manufacturerDiscount to improve mobile input. Also apply minor JSX formatting/template-string cleanup in inventory-management (ternary & className formatting). Update Sidebar label to "View Sales / Refund Sales" to reflect refunds (components/Sidebar.tsx).