### PR TITLE
Support optional genericName across inventory/UI

### DIFF
--- a/app/(root)/pharmacist/inventory-management/page.tsx
+++ b/app/(root)/pharmacist/inventory-management/page.tsx
@@ -69,6 +69,7 @@ const baseSchema = z.object({
 const medicineSchema = baseSchema.extend({
   dosage: z.string().min(1, "Dosage is required"),
   activeIngredient: z.string().min(1, "Active ingredient is required"),
+  genericName: z.string().optional(),
 });
 
 const injectionSchema = baseSchema.extend({
@@ -133,6 +134,7 @@ export default function InventoryManagement() {
       description: "",
       dosage: "",
       activeIngredient: "",
+      genericName: "",
       volume: "",
       route: "Intramuscular",
       sterilizationMethod: "",
@@ -189,6 +191,7 @@ export default function InventoryManagement() {
     description: "",
     dosage: "",
     activeIngredient: "",
+    genericName: "",
     volume: "",
     route: "Intramuscular" as const,
     sterilizationMethod: "",
@@ -212,6 +215,7 @@ export default function InventoryManagement() {
       ...(itemType === ItemType.MEDICINE && {
         dosage: data.dosage,
         activeIngredient: data.activeIngredient,
+        genericName: data.genericName,
       }),
       ...(itemType === ItemType.INJECTION && {
         volume: data.volume,
@@ -558,6 +562,20 @@ export default function InventoryManagement() {
                     {form.formState.errors.activeIngredient && (
                       <span className="text-red-500 text-sm">
                         {form.formState.errors.activeIngredient.message}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="genericName">Generic Name</Label>
+                    <Input
+                      id="genericName"
+                      placeholder="Generic name (optional)"
+                      className="text-lg p-4"
+                      {...form.register("genericName")}
+                    />
+                    {form.formState.errors.genericName && (
+                      <span className="text-red-500 text-sm">
+                        {form.formState.errors.genericName.message}
                       </span>
                     )}
                   </div>

--- a/app/(root)/pharmacist/inventory-view/page.tsx
+++ b/app/(root)/pharmacist/inventory-view/page.tsx
@@ -59,7 +59,8 @@ const Inventory = () => {
   }, [items]);
 
   const filteredItems = items.filter((item) => {
-    const matchesSearch = item.name.toLowerCase().includes(search.toLowerCase());
+    const term = search.toLowerCase();
+    const matchesSearch = item.name.toLowerCase().includes(term) || (item.genericName && item.genericName.toLowerCase().includes(term));
     const matchesType = typeFilter === "all" || item.type === typeFilter;
     const matchesCategory =
       categoryFilter === "all" ||

--- a/app/(root)/pharmacist/page.tsx
+++ b/app/(root)/pharmacist/page.tsx
@@ -205,8 +205,8 @@ const PharmacistPage = () => {
         const dataLast = await resLast.json();
         const salesThis = dataThis?.success && Array.isArray(dataThis?.data) ? dataThis.data : [];
         const salesLast = dataLast?.success && Array.isArray(dataLast?.data) ? dataLast.data : [];
-        setEarnedThisMonth(salesThis.reduce((sum: number, s: { totalPrice?: number }) => sum + (s.totalPrice ?? 0), 0));
-        setEarnedLastMonth(salesLast.reduce((sum: number, s: { totalPrice?: number }) => sum + (s.totalPrice ?? 0), 0));
+        setEarnedThisMonth(salesThis.reduce((sum: number, s: { totalPrice?: number; refundedAmount?: number }) => sum + (s.totalPrice ?? 0) - (s.refundedAmount ?? 0), 0));
+        setEarnedLastMonth(salesLast.reduce((sum: number, s: { totalPrice?: number; refundedAmount?: number }) => sum + (s.totalPrice ?? 0) - (s.refundedAmount ?? 0), 0));
       } catch (e) {
         console.error("Error fetching sales for stats:", e);
       }

--- a/app/(root)/pharmacist/sales/page.tsx
+++ b/app/(root)/pharmacist/sales/page.tsx
@@ -42,6 +42,7 @@ interface Product {
   quantity: number;
   imageUrl: string;
   type: string;
+  genericName?: string;
 }
 
 interface CartItem extends Product {
@@ -131,7 +132,8 @@ const SalesPage = () => {
     if (searchTerm) {
       const results = products.filter((product) => {
         const productName = product.name ? product.name.toLowerCase() : "";
-        return productName.includes(searchTerm.toLowerCase());
+        const genericName = product.genericName ? product.genericName.toLowerCase() : "";
+        return productName.includes(searchTerm.toLowerCase()) || genericName.includes(searchTerm.toLowerCase());
       });
       setSearchResults(results);
     } else {
@@ -154,6 +156,7 @@ const SalesPage = () => {
         quantity: data.quantity ?? 0,
         imageUrl: data.image ?? "",
         type: data.type ?? "GENERAL",
+        genericName: data.genericName,
       };
       setProducts((prev) => {
         if (prev.some((p) => p.id === product.id)) return prev;
@@ -739,7 +742,7 @@ const SalesPage = () => {
             <div className="print:p-0 print-content" id="receipt-print-area">
               <Receipt
                 cart={cart}
-                discount={discountAmount.toString()}
+                discount={discount || "0"}
                 totalBill={totalBill}
                 discountedTotal={discountedTotal}
                 invoiceNumber={completedSale?.invoiceNumber || sessionInvoiceNumber}

--- a/app/context/InventoryContext.tsx
+++ b/app/context/InventoryContext.tsx
@@ -13,6 +13,7 @@ export enum ItemType {
 export interface InventoryItem {
   id: string;
   name: string;
+  genericName?: string;
   type: ItemType; // Use the locally defined ItemType enum
   quantity: number;
   batchNumber: string;


### PR DESCRIPTION
Add an optional genericName field to inventory and product types and wire it through the UI and search. Changes include:

- app/context/InventoryContext.tsx: Add genericName?: string to InventoryItem.
- app/(root)/pharmacist/inventory-management/page.tsx: Extend medicine Zod schema with optional genericName, initialize form values, include genericName when building medicine items, and add a Generic Name input with validation display.
- app/(root)/pharmacist/inventory-view/page.tsx: Include genericName in search filtering so searches match either name or genericName.
- app/(root)/pharmacist/sales/page.tsx: Add genericName to Product type, include it when mapping loaded products, and include genericName in sales search matching. Also change receipt discount prop to pass discount || "0".
- app/(root)/pharmacist/page.tsx: Adjust monthly earnings calculations to subtract refundedAmount from totalPrice when summing sales.

These updates enable storing and searching by generic names and ensure UI and summary calculations account for related fields.