### PR TITLE
Add pagination to inventory and list endpoints

### DIFF
--- a/app/(root)/pharmacist/inventory-view/page.tsx
+++ b/app/(root)/pharmacist/inventory-view/page.tsx
@@ -52,8 +52,8 @@ const Inventory = () => {
       setLoading(true);
       const lowStock = await getLowStockItems();
       const expiring = await getExpiringItems();
-      setLowStockItems(lowStock);
-      setExpiringItems(expiring);
+      setLowStockItems(lowStock.data);
+      setExpiringItems(expiring.data);
       setLoading(false);
     };
     fetchData();

--- a/app/(root)/pharmacist/manufacturer-working/page.tsx
+++ b/app/(root)/pharmacist/manufacturer-working/page.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import ManufacturerModal from "./Modal";
+import { PaginationControls } from "@/components/shared/PaginationControls";
 
 interface ManufacturerRow {
   id: string;
@@ -69,6 +70,10 @@ const Manufacturer = () => {
   const [manufacturers, setManufacturers] = useState<ManufacturerRow[]>([]);
   const [manufacturersRaw, setManufacturersRaw] = useState<ManufacturerRaw[]>([]);
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const LIMIT = 20;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedManufacturer, setSelectedManufacturer] = useState<ManufacturerRow | null>(null);
   const [viewManufacturer, setViewManufacturer] = useState<ManufacturerRaw | null>(null);
@@ -77,19 +82,18 @@ const Manufacturer = () => {
   const { user } = useAuth();
   const accessToken = user?.access_token;
 
-  const fetchManufacturers = async () => {
+  const fetchManufacturers = async (targetPage = 1) => {
     setLoading(true);
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/manufacturer`
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/manufacturer?page=${targetPage}&limit=${LIMIT}`
       );
       if (!response.ok) {
         throw new Error("Failed to fetch manufacturers");
       }
 
-      const data = await response.json();
-
-      const manufacturersArray = Array.isArray(data) ? data : [data];
+      const result = await response.json();
+      const manufacturersArray = Array.isArray(result) ? result : (result.data ?? []);
 
       const mappedData = manufacturersArray.map((item: any) => ({
         id: item.id,
@@ -107,6 +111,11 @@ const Manufacturer = () => {
 
       setManufacturers(mappedData);
       setManufacturersRaw(manufacturersArray);
+      if (result.meta) {
+        setTotalPages(result.meta.totalPages);
+        setTotal(result.meta.total);
+        setPage(result.meta.page);
+      }
     } catch (error) {
       console.error("Error fetching manufacturers:", error);
     } finally {
@@ -318,6 +327,7 @@ const Manufacturer = () => {
               </motion.div>
             )}
           </AnimatePresence>
+          <PaginationControls page={page} totalPages={totalPages} total={total} limit={LIMIT} loading={loading} onPageChange={(p) => { setPage(p); fetchManufacturers(p); }} />
           </CardContent>
         </Card>
 

--- a/app/(root)/pharmacist/page.tsx
+++ b/app/(root)/pharmacist/page.tsx
@@ -31,6 +31,7 @@ import axios from "axios";
 import { toast } from "sonner";
 import { dispatchExpiringInvalidated } from "@/lib/expiring-events";
 import { EXPIRING_INVALIDATED_EVENT } from "@/lib/expiring-events";
+import { PaginationControls } from "@/components/shared/PaginationControls";
 import type { ColumnDef } from "@tanstack/react-table";
 
 function getMonthRange(monthOffset: number) {
@@ -52,6 +53,11 @@ const PharmacistPage = () => {
   const [expiringItems, setExpiringItems] = useState<InventoryItem[]>([]);
   const [lowStockCount, setLowStockCount] = useState(0);
   const [expiringCount, setExpiringCount] = useState(0);
+  const [lowStockPage, setLowStockPage] = useState(1);
+  const [lowStockTotalPages, setLowStockTotalPages] = useState(1);
+  const [expiringPage, setExpiringPage] = useState(1);
+  const [expiringTotalPages, setExpiringTotalPages] = useState(1);
+  const TABLE_LIMIT = 20;
   const [earnedThisMonth, setEarnedThisMonth] = useState(0);
   const [earnedLastMonth, setEarnedLastMonth] = useState(0);
   const [itemToDiscard, setItemToDiscard] = useState<InventoryItem | null>(null);
@@ -68,14 +74,25 @@ const PharmacistPage = () => {
     transition: { duration: 0.6 },
   };
 
+  const fetchLowStock = useCallback(async (page = 1) => {
+    const result = await getLowStockItems(page, TABLE_LIMIT);
+    setLowStockItems(result.data);
+    setLowStockCount(result.meta.total);
+    setLowStockPage(result.meta.page);
+    setLowStockTotalPages(result.meta.totalPages);
+  }, [getLowStockItems, TABLE_LIMIT]);
+
+  const fetchExpiring = useCallback(async (page = 1) => {
+    const result = await getExpiringItems(page, TABLE_LIMIT);
+    setExpiringItems(result.data);
+    setExpiringCount(result.meta.total);
+    setExpiringPage(result.meta.page);
+    setExpiringTotalPages(result.meta.totalPages);
+  }, [getExpiringItems, TABLE_LIMIT]);
+
   const fetchData = useCallback(async () => {
-    const lowStock = await getLowStockItems();
-    const expiring = await getExpiringItems();
-    setLowStockItems(lowStock);
-    setExpiringItems(expiring);
-    setLowStockCount(lowStock.length);
-    setExpiringCount(expiring.length);
-  }, [getLowStockItems, getExpiringItems]);
+    await Promise.all([fetchLowStock(1), fetchExpiring(1)]);
+  }, [fetchLowStock, fetchExpiring]);
 
   useEffect(() => {
     fetchData();
@@ -262,6 +279,7 @@ const PharmacistPage = () => {
               </div>
               <div className="p-4 sm:p-5">
                 <DataTable columns={expiringTableColumns} data={lowStockItems} />
+                <PaginationControls page={lowStockPage} totalPages={lowStockTotalPages} total={lowStockCount} limit={TABLE_LIMIT} onPageChange={(p) => fetchLowStock(p)} />
               </div>
             </Card>
           </motion.div>
@@ -282,6 +300,7 @@ const PharmacistPage = () => {
               </div>
               <div className="p-4 sm:p-5">
                 <DataTable columns={dashboardExpiringColumns} data={expiringItems} disableRowClick />
+                <PaginationControls page={expiringPage} totalPages={expiringTotalPages} total={expiringCount} limit={TABLE_LIMIT} onPageChange={(p) => fetchExpiring(p)} />
               </div>
             </Card>
           </motion.div>

--- a/app/(root)/pharmacist/purchase-orders/create/page.tsx
+++ b/app/(root)/pharmacist/purchase-orders/create/page.tsx
@@ -257,8 +257,8 @@ export default function CreatePurchaseOrdersPage() {
         axios.get(`${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/low-stock`, { headers }),
         axios.get(`${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/expiring`, { headers }),
       ]);
-      const lowStock = lowRes.data ?? [];
-      const expiring = expiringRes.data ?? [];
+      const lowStock = lowRes.data?.data ?? lowRes.data ?? [];
+      const expiring = expiringRes.data?.data ?? expiringRes.data ?? [];
       const merged = mergeLowStockAndExpiring(lowStock, expiring);
       setItems(merged);
       setError(null);

--- a/app/(root)/pharmacist/vendor-working/page.tsx
+++ b/app/(root)/pharmacist/vendor-working/page.tsx
@@ -22,6 +22,7 @@ import { useAuth } from "@/app/providers/AuthProvider";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import VendorModal, { type VendorRaw } from "./Modal";
+import { PaginationControls } from "@/components/shared/PaginationControls";
 
 interface VendorRow {
   id: string;
@@ -38,6 +39,10 @@ export default function VendorsPage() {
   const [search, setSearch] = useState("");
   const [vendorsRaw, setVendorsRaw] = useState<VendorRaw[]>([]);
   const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const LIMIT = 20;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editVendor, setEditVendor] = useState<VendorRaw | null>(null);
   const [selected, setSelected] = useState<VendorRow | null>(null);
@@ -46,18 +51,23 @@ export default function VendorsPage() {
   const { user } = useAuth();
   const accessToken = user?.access_token;
 
-  const fetchVendors = async () => {
+  const fetchVendors = async (targetPage = 1) => {
     setLoading(true);
     try {
       const headers: HeadersInit = {};
       if (accessToken) {
         (headers as Record<string, string>).Authorization = `Bearer ${accessToken}`;
       }
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/vendor`, { headers });
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/vendor?page=${targetPage}&limit=${LIMIT}`, { headers });
       if (!res.ok) throw new Error("Failed to fetch vendors");
-      const data: VendorRaw[] = await res.json();
-      const list = Array.isArray(data) ? data : [];
+      const result = await res.json();
+      const list: VendorRaw[] = Array.isArray(result) ? result : (result.data ?? []);
       setVendorsRaw(list);
+      if (result.meta) {
+        setTotalPages(result.meta.totalPages);
+        setTotal(result.meta.total);
+        setPage(result.meta.page);
+      }
     } catch (e) {
       console.error(e);
     } finally {
@@ -260,6 +270,7 @@ export default function VendorsPage() {
                 </motion.div>
               )}
             </AnimatePresence>
+            <PaginationControls page={page} totalPages={totalPages} total={total} limit={LIMIT} loading={loading} onPageChange={(p) => { setPage(p); fetchVendors(p); }} />
           </CardContent>
         </Card>
 

--- a/app/context/InventoryContext.tsx
+++ b/app/context/InventoryContext.tsx
@@ -60,6 +60,18 @@ const initialState: InventoryState = {
   items: [],
 };
 
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  meta: PaginationMeta;
+}
+
 const InventoryContext = createContext<{
   state: InventoryState;
   dispatch: React.Dispatch<InventoryAction>;
@@ -71,8 +83,8 @@ const InventoryContext = createContext<{
     item: Omit<InventoryItem, "id" | "createdAt" | "updatedAt">
   ) => Promise<void>;
   deleteItem: (id: string) => Promise<void>;
-  getLowStockItems: () => Promise<InventoryItem[]>;
-  getExpiringItems: () => Promise<InventoryItem[]>;
+  getLowStockItems: (page?: number, limit?: number) => Promise<PaginatedResult<InventoryItem>>;
+  getExpiringItems: (page?: number, limit?: number) => Promise<PaginatedResult<InventoryItem>>;
   /** Refetch inventory from API (e.g. after sale or refund) so quantities stay in sync */
   refetchInventory: () => Promise<void>;
 } | null>(null);
@@ -182,29 +194,25 @@ export const InventoryProvider = ({
     }
   };
 
-  const getLowStockItems = async (): Promise<InventoryItem[]> => {
+  const getLowStockItems = useCallback(async (page = 1, limit = 20): Promise<PaginatedResult<InventoryItem>> => {
     const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/low-stock`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      }
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/low-stock?page=${page}&limit=${limit}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
     );
-    return sortByLocaleKey(response.data as InventoryItem[], (i) => i.name);
-  };
+    const result = response.data;
+    const data = sortByLocaleKey(result.data ?? result, (i: InventoryItem) => i.name);
+    return { data, meta: result.meta ?? { total: data.length, page, limit, totalPages: 1 } };
+  }, [accessToken]);
 
-  const getExpiringItems = async (): Promise<InventoryItem[]> => {
+  const getExpiringItems = useCallback(async (page = 1, limit = 20): Promise<PaginatedResult<InventoryItem>> => {
     const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/expiring`,
-      {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      }
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/expiring?page=${page}&limit=${limit}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
     );
-    return sortByLocaleKey(response.data as InventoryItem[], (i) => i.name);
-  };
+    const result = response.data;
+    const data = sortByLocaleKey(result.data ?? result, (i: InventoryItem) => i.name);
+    return { data, meta: result.meta ?? { total: data.length, page, limit, totalPages: 1 } };
+  }, [accessToken]);
 
   return (
     <InventoryContext.Provider

--- a/components/ExpiringSoonBanner.tsx
+++ b/components/ExpiringSoonBanner.tsx
@@ -21,9 +21,9 @@ export function ExpiringSoonBanner() {
   const fetchExpiring = useCallback(async () => {
     if (user?.role !== "pharmacist") return;
     try {
-      const items = await getExpiringItems();
-      setExpiringCount(items.length);
-      return items.length;
+      const result = await getExpiringItems();
+      setExpiringCount(result.meta.total);
+      return result.meta.total;
     } catch {
       setExpiringCount(0);
       return 0;

--- a/components/LowStockReminderBanner.tsx
+++ b/components/LowStockReminderBanner.tsx
@@ -23,9 +23,9 @@ export function LowStockReminderBanner() {
   const fetchLowStock = useCallback(async () => {
     if (user?.role !== "pharmacist") return;
     try {
-      const items = await getLowStockItems();
-      setLowStockCount(items.length);
-      return items.length;
+      const result = await getLowStockItems();
+      setLowStockCount(result.meta.total);
+      return result.meta.total;
     } catch {
       setLowStockCount(0);
       return 0;

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -44,8 +44,8 @@ const Sidebar = () => {
       return;
     }
 
-    const refreshLow = () => getLowStockItems().then((items) => setLowStockCount(items.length));
-    const refreshExpiring = () => getExpiringItems().then((items) => setExpiringCount(items.length));
+    const refreshLow = () => getLowStockItems().then((r) => setLowStockCount(r.meta.total));
+    const refreshExpiring = () => getExpiringItems().then((r) => setExpiringCount(r.meta.total));
     const refresh = () => {
       refreshLow();
       refreshExpiring();


### PR DESCRIPTION
Convert low-stock and expiring item APIs to return paginated results and propagate pagination metadata through the InventoryContext. Change getLowStockItems/getExpiringItems to return PaginatedResult<{InventoryItem}> and preserve sorting, with sensible fallback meta. Update pages (pharmacist dashboard, manufacturer, vendor, purchase order create) and components to consume result.data and result.meta (counts, pages, totals) and add PaginationControls where appropriate. Also adjust banners and sidebar to read meta.total for counts and handle nested response shapes (e.g. response.data.data) when merging API responses. These changes enable server-side pagination and UI controls while maintaining backward-compatible fallbacks.