### PR TITLE
Add count APIs for low stock/expiring and use them

### DIFF
--- a/app/context/InventoryContext.tsx
+++ b/app/context/InventoryContext.tsx
@@ -85,6 +85,8 @@ const InventoryContext = createContext<{
   deleteItem: (id: string) => Promise<void>;
   getLowStockItems: (page?: number, limit?: number) => Promise<PaginatedResult<InventoryItem>>;
   getExpiringItems: (page?: number, limit?: number) => Promise<PaginatedResult<InventoryItem>>;
+  getLowStockCount: () => Promise<number>;
+  getExpiringCount: () => Promise<number>;
   /** Refetch inventory from API (e.g. after sale or refund) so quantities stay in sync */
   refetchInventory: () => Promise<void>;
 } | null>(null);
@@ -194,6 +196,22 @@ export const InventoryProvider = ({
     }
   };
 
+  const getLowStockCount = useCallback(async (): Promise<number> => {
+    const response = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/low-stock?countOnly=true`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    return response.data?.total ?? 0;
+  }, [accessToken]);
+
+  const getExpiringCount = useCallback(async (): Promise<number> => {
+    const response = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/expiring?countOnly=true`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    return response.data?.total ?? 0;
+  }, [accessToken]);
+
   const getLowStockItems = useCallback(async (page = 1, limit = 20): Promise<PaginatedResult<InventoryItem>> => {
     const response = await axios.get(
       `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/low-stock?page=${page}&limit=${limit}`,
@@ -224,6 +242,8 @@ export const InventoryProvider = ({
         deleteItem,
         getLowStockItems,
         getExpiringItems,
+        getLowStockCount,
+        getExpiringCount,
         refetchInventory,
       }}
     >

--- a/components/ExpiringSoonBanner.tsx
+++ b/components/ExpiringSoonBanner.tsx
@@ -14,23 +14,23 @@ const EXPIRING_TOAST_KEY = "expiring-soon-toast-last-shown";
 
 export function ExpiringSoonBanner() {
   const { user } = useAuth();
-  const { getExpiringItems } = useInventory();
+  const { getExpiringCount } = useInventory();
   const [expiringCount, setExpiringCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
 
   const fetchExpiring = useCallback(async () => {
     if (user?.role !== "pharmacist") return;
     try {
-      const result = await getExpiringItems();
-      setExpiringCount(result.meta.total);
-      return result.meta.total;
+      const count = await getExpiringCount();
+      setExpiringCount(count);
+      return count;
     } catch {
       setExpiringCount(0);
       return 0;
     } finally {
       setIsLoading(false);
     }
-  }, [user?.role, getExpiringItems]);
+  }, [user?.role, getExpiringCount]);
 
   useEffect(() => {
     if (user?.role !== "pharmacist") return;

--- a/components/LowStockReminderBanner.tsx
+++ b/components/LowStockReminderBanner.tsx
@@ -15,7 +15,7 @@ const LOW_STOCK_TOAST_KEY = "low-stock-toast-last-shown";
 
 export function LowStockReminderBanner() {
   const { user } = useAuth();
-  const { getLowStockItems } = useInventory();
+  const { getLowStockCount } = useInventory();
   const pathname = usePathname();
   const [lowStockCount, setLowStockCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -23,16 +23,16 @@ export function LowStockReminderBanner() {
   const fetchLowStock = useCallback(async () => {
     if (user?.role !== "pharmacist") return;
     try {
-      const result = await getLowStockItems();
-      setLowStockCount(result.meta.total);
-      return result.meta.total;
+      const count = await getLowStockCount();
+      setLowStockCount(count);
+      return count;
     } catch {
       setLowStockCount(0);
       return 0;
     } finally {
       setIsLoading(false);
     }
-  }, [user?.role, getLowStockItems]);
+  }, [user?.role, getLowStockCount]);
 
   useEffect(() => {
     if (user?.role !== "pharmacist") return;

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -26,7 +26,7 @@ const Sidebar = () => {
   const pathname = usePathname();
   const role = user?.role;
   const router = useRouter();
-  const { getLowStockItems, getExpiringItems } = useInventory();
+  const { getLowStockCount, getExpiringCount } = useInventory();
   const [lowStockCount, setLowStockCount] = useState(0);
   const [expiringCount, setExpiringCount] = useState(0);
 
@@ -44,8 +44,8 @@ const Sidebar = () => {
       return;
     }
 
-    const refreshLow = () => getLowStockItems().then((r) => setLowStockCount(r.meta.total));
-    const refreshExpiring = () => getExpiringItems().then((r) => setExpiringCount(r.meta.total));
+    const refreshLow = () => getLowStockCount().then(setLowStockCount);
+    const refreshExpiring = () => getExpiringCount().then(setExpiringCount);
     const refresh = () => {
       refreshLow();
       refreshExpiring();
@@ -57,7 +57,7 @@ const Sidebar = () => {
       window.removeEventListener(LOW_STOCK_INVALIDATED_EVENT, refreshLow);
       window.removeEventListener(EXPIRING_INVALIDATED_EVENT, refreshExpiring);
     };
-  }, [role, pathname, getLowStockItems, getExpiringItems]);
+  }, [role, pathname, getLowStockCount, getExpiringCount]);
 
   const handleLogout = (event: React.MouseEvent) => {
     event.preventDefault();


### PR DESCRIPTION
Introduce getLowStockCount and getExpiringCount in InventoryContext (calls API with countOnly=true) and expose them from the provider. Update components (ExpiringSoonBanner, LowStockReminderBanner, Sidebar) to use the new count methods instead of fetching full item lists, simplifying state updates and hook dependencies. Adjusted effect dependencies and sidebar refresh handlers to call the count endpoints and set counts directly.