### PR TITLE
Add server pagination/search to inventory view

### DIFF
--- a/app/(root)/pharmacist/inventory-view/page.tsx
+++ b/app/(root)/pharmacist/inventory-view/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { DataTable } from "@/components/shared/DataTable";
-import { useInventory } from "@/app/context/InventoryContext";
 import { inventoryColumns } from "@/components/shared/columns";
 import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
-import { Search, Filter } from "lucide-react";
+import { Search } from "lucide-react";
 import Loading from "@/components/shared/Loading";
 import {
   Select,
@@ -18,58 +17,82 @@ import {
 } from "@/components/ui/select";
 import { InventoryItem } from "@/app/context/InventoryContext";
 import { sortByLocaleKey } from "@/lib/sort-alphabetical";
+import { PaginationControls } from "@/components/shared/PaginationControls";
+import { useAuth } from "@/app/providers/AuthProvider";
+import axios from "axios";
+
+const LIMIT = 50;
 
 const Inventory = () => {
-  const {
-    state: { items },
-    getLowStockItems,
-    getExpiringItems,
-    refetchInventory,
-  } = useInventory();
+  const { user } = useAuth();
+  const accessToken = user?.access_token;
 
+  const [items, setItems] = useState<InventoryItem[]>([]);
   const [search, setSearch] = useState("");
   const [typeFilter, setTypeFilter] = useState<string>("all");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [loading, setLoading] = useState(true);
-  const [lowStockItems, setLowStockItems] = useState<InventoryItem[]>([]);
-  const [expiringItems, setExpiringItems] = useState<InventoryItem[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
 
-  const categories = Array.from(
-    new Set(
-      items
-        .map((item) => item.category)
-        .filter((c): c is string => !!c && c.trim() !== "")
-    )
-  ).sort();
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
-  // Refetch inventory when this page is shown so quantities are up to date after sales/refunds
-  useEffect(() => {
-    refetchInventory();
-  }, [refetchInventory]);
+  const fetchItems = useCallback(async (targetPage: number, searchTerm: string) => {
+    if (!accessToken) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      params.set("page", String(targetPage));
+      params.set("limit", String(LIMIT));
+      if (searchTerm.trim()) params.set("search", searchTerm.trim());
 
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      const lowStock = await getLowStockItems();
-      const expiring = await getExpiringItems();
-      setLowStockItems(lowStock.data);
-      setExpiringItems(expiring.data);
+      const { data: result } = await axios.get(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist?${params}`,
+        { headers: { Authorization: `Bearer ${accessToken}` } }
+      );
+
+      const raw = result.data ?? result;
+      setItems(sortByLocaleKey(raw, (i: InventoryItem) => i.name));
+      if (result.meta) {
+        setPage(result.meta.page);
+        setTotalPages(result.meta.totalPages);
+        setTotal(result.meta.total);
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
       setLoading(false);
-    };
-    fetchData();
-  }, [items]);
+    }
+  }, [accessToken]);
 
-  const filteredItems = sortByLocaleKey(
+  // Initial load
+  useEffect(() => {
+    fetchItems(1, "");
+  }, [fetchItems]);
+
+  // Debounced server search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setPage(1);
+      fetchItems(1, search);
+    }, 300);
+    return () => clearTimeout(debounceRef.current!);
+  }, [search, fetchItems]);
+
+  const categories = useMemo(() =>
+    Array.from(new Set(items.map((i) => i.category).filter((c): c is string => !!c && c.trim() !== ""))).sort(),
+    [items]
+  );
+
+  const filteredItems = useMemo(() =>
     items.filter((item) => {
-      const term = search.toLowerCase();
-      const matchesSearch = item.name.toLowerCase().includes(term) || (item.genericName && item.genericName.toLowerCase().includes(term));
       const matchesType = typeFilter === "all" || item.type === typeFilter;
-      const matchesCategory =
-        categoryFilter === "all" ||
-        (item.category && item.category === categoryFilter);
-      return matchesSearch && matchesType && matchesCategory;
+      const matchesCategory = categoryFilter === "all" || item.category === categoryFilter;
+      return matchesType && matchesCategory;
     }),
-    (item) => item.name,
+    [items, typeFilter, categoryFilter]
   );
 
   return (
@@ -85,7 +108,7 @@ const Inventory = () => {
             Inventory
           </motion.h1>
           <motion.p className="mt-1 text-sm text-gray-500" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.1 }}>
-            View and filter inventory items. The table includes list purchase, manufacturer %, and special company % (used together for net cost on stock and profit reports).
+            View and filter inventory items.
           </motion.p>
           <div className="mt-4 h-px bg-gradient-to-r from-red-200/80 via-red-100/50 to-transparent rounded-full" />
         </header>
@@ -94,93 +117,86 @@ const Inventory = () => {
           <div className="border-l-4 border-l-red-500 bg-red-50/30 px-5 py-3">
             <h2 className="text-base font-semibold text-red-800">Inventory list</h2>
             <p className="text-xs text-gray-500 mt-0.5">
-              Search and filter by type or category.
+              {total > 0 && !loading && `${total} total items · page ${page} of ${totalPages}`}
             </p>
           </div>
           <CardContent className="p-4 sm:p-5">
-          <div className="space-y-6">
-            {loading ? (
-              <div className="min-h-[280px] flex items-center justify-center">
-                <Loading />
-              </div>
-            ) : (
-              <>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-4">
-                  <div className="relative">
-                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-                    <Input
-                      placeholder="Search items..."
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
-                      className="pl-9 h-10 border-gray-200 focus:border-red-500 focus:ring-red-500/20"
-                    />
-                  </div>
-                  <div className="relative">
-                    <Select
-                      onValueChange={(value) => setTypeFilter(value)}
-                      value={typeFilter}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Filter by type" className="pl-10 pr-4 py-2" />
-                      </SelectTrigger>
-                      <SelectContent>
-                          <SelectItem className="text-lg" value="all">All types</SelectItem>
-                          <SelectItem className="text-lg" value="MEDICINE">Medicine</SelectItem>
-                          <SelectItem className="text-lg" value="SYRUP">Syrup</SelectItem>
-                          <SelectItem className="text-lg" value="SURGERY">Surgery</SelectItem>
-                          <SelectItem className="text-lg" value="INJECTION">Injection</SelectItem>
-                          <SelectItem className="text-lg" value="GENERAL">General</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="relative">
-                    <Select
-                      onValueChange={(value) => setCategoryFilter(value)}
-                      value={categoryFilter}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Category" className="pl-10 pr-4 py-2" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem className="text-lg" value="all">All categories</SelectItem>
-                        {categories.map((cat) => (
-                          <SelectItem key={cat} className="text-lg" value={cat}>
-                            {cat}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="sm:col-span-2 lg:col-span-2 flex items-center justify-end space-x-2">
-                    <div className="text-sm text-muted-foreground font-medium">
-                      Showing {filteredItems.length} item{filteredItems.length !== 1 ? "s" : ""}
-                    </div>
-                  </div>
+            <div className="space-y-6">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-4">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+                  <Input
+                    placeholder="Search items..."
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    className="pl-9 h-10 border-gray-200 focus:border-red-500 focus:ring-red-500/20"
+                  />
                 </div>
+                <Select onValueChange={setTypeFilter} value={typeFilter}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Filter by type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All types</SelectItem>
+                    <SelectItem value="MEDICINE">Medicine</SelectItem>
+                    <SelectItem value="SYRUP">Syrup</SelectItem>
+                    <SelectItem value="SURGERY">Surgery</SelectItem>
+                    <SelectItem value="INJECTION">Injection</SelectItem>
+                    <SelectItem value="GENERAL">General</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select onValueChange={setCategoryFilter} value={categoryFilter}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Category" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All categories</SelectItem>
+                    {categories.map((cat) => (
+                      <SelectItem key={cat} value={cat}>{cat}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <div className="sm:col-span-2 flex items-center justify-end text-sm text-muted-foreground font-medium">
+                  Showing {filteredItems.length} item{filteredItems.length !== 1 ? "s" : ""}
+                </div>
+              </div>
 
+              {loading ? (
+                <div className="min-h-[280px] flex items-center justify-center">
+                  <Loading />
+                </div>
+              ) : filteredItems.length === 0 ? (
+                <motion.div
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  className="flex flex-col items-center justify-center py-12 px-4 rounded-lg bg-gray-50/80"
+                >
+                  <div className="h-14 w-14 rounded-full bg-gray-100 flex items-center justify-center mb-3">
+                    <Search className="h-7 w-7 text-gray-400" />
+                  </div>
+                  <p className="text-sm font-medium text-gray-600">No items found</p>
+                  <p className="text-sm text-gray-500">Try adjusting your search or filter.</p>
+                </motion.div>
+              ) : (
                 <div className="rounded-lg border border-gray-100 overflow-hidden">
                   <DataTable columns={inventoryColumns} data={filteredItems} />
                 </div>
-              </>
-            )}
-            {filteredItems.length === 0 && !loading && (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="flex flex-col items-center justify-center py-12 px-4 rounded-lg bg-gray-50/80"
-              >
-                <div className="h-14 w-14 rounded-full bg-gray-100 flex items-center justify-center mb-3">
-                  <Search className="h-7 w-7 text-gray-400" />
-                </div>
-                <p className="text-sm font-medium text-gray-600">No items found</p>
-                <p className="text-sm text-gray-500">
-                  Try adjusting your search or filter to find what you're looking for.
-                </p>
-              </motion.div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+              )}
+
+              <PaginationControls
+                page={page}
+                totalPages={totalPages}
+                total={total}
+                limit={LIMIT}
+                loading={loading}
+                onPageChange={(p) => {
+                  setPage(p);
+                  fetchItems(p, search);
+                }}
+              />
+            </div>
+          </CardContent>
+        </Card>
       </div>
     </div>
   );

--- a/components/shared/DataTable.tsx
+++ b/components/shared/DataTable.tsx
@@ -56,10 +56,9 @@ export function DataTable<TData extends Record<string, any>, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
     state: { sorting },
-    // Limit rows per page to 4
     initialState: {
       pagination: {
-        pageSize: 4,
+        pageSize: 20,
       },
     },
   });


### PR DESCRIPTION
Switch inventory page to fetch items from the API using useAuth token (axios) with a LIMIT, debounced server-side search, and page metadata handling. Introduce pagination controls, memoized categories, loading and empty states, and remove previous InventoryContext low-stock/expiring logic. Minor UI cleanup (trimmed CardHeader imports, removed unused icons). Also increase DataTable default pageSize from 4 to 20.