### PR TITLE
Add disablePagination & lower inventory limit

### DIFF
--- a/app/(root)/pharmacist/inventory-view/page.tsx
+++ b/app/(root)/pharmacist/inventory-view/page.tsx
@@ -21,7 +21,7 @@ import { PaginationControls } from "@/components/shared/PaginationControls";
 import { useAuth } from "@/app/providers/AuthProvider";
 import axios from "axios";
 
-const LIMIT = 50;
+const LIMIT = 20;
 
 const Inventory = () => {
   const { user } = useAuth();
@@ -156,9 +156,7 @@ const Inventory = () => {
                     ))}
                   </SelectContent>
                 </Select>
-                <div className="sm:col-span-2 flex items-center justify-end text-sm text-muted-foreground font-medium">
-                  Showing {filteredItems.length} item{filteredItems.length !== 1 ? "s" : ""}
-                </div>
+                <div className="sm:col-span-2" />
               </div>
 
               {loading ? (
@@ -179,7 +177,7 @@ const Inventory = () => {
                 </motion.div>
               ) : (
                 <div className="rounded-lg border border-gray-100 overflow-hidden">
-                  <DataTable columns={inventoryColumns} data={filteredItems} />
+                  <DataTable columns={inventoryColumns} data={filteredItems} disablePagination />
                 </div>
               )}
 

--- a/components/shared/DataTable.tsx
+++ b/components/shared/DataTable.tsx
@@ -34,6 +34,7 @@ interface DataTableProps<TData, TValue> {
   data: TData[];
   onRowClick?: (row: TData) => void;
   disableRowClick?: boolean;
+  disablePagination?: boolean;
   /** Default sort when the table loads. Column `id` must match sorting id (often same as accessorKey). */
   initialSorting?: SortingState;
 }
@@ -43,6 +44,7 @@ export function DataTable<TData extends Record<string, any>, TValue>({
   data,
   onRowClick,
   disableRowClick,
+  disablePagination = false,
   initialSorting = [{ id: "name", desc: false }],
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>(initialSorting);
@@ -151,30 +153,32 @@ export function DataTable<TData extends Record<string, any>, TValue>({
             )}
           </TableBody>
         </Table>
-      <div className="flex flex-col sm:flex-row items-center justify-between space-y-2 sm:space-y-0 py-4">
-        <div className="text-sm text-muted-foreground">
-          Page {table.getState().pagination.pageIndex + 1} of{" "}
-          {table.getPageCount()}
+      {!disablePagination && (
+        <div className="flex flex-col sm:flex-row items-center justify-between space-y-2 sm:space-y-0 py-4">
+          <div className="text-sm text-muted-foreground">
+            Page {table.getState().pagination.pageIndex + 1} of{" "}
+            {table.getPageCount()}
+          </div>
+          <div className="space-x-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+            >
+              Next
+            </Button>
+          </div>
         </div>
-        <div className="space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-          >
-            Previous
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-          >
-            Next
-          </Button>
-        </div>
-      </div>
+      )}
 
       <Dialog open={!!selectedRow} onOpenChange={closeModal}>
         <DialogContent className="sm:max-w-[900px] p-0 overflow-hidden">


### PR DESCRIPTION
Introduce a disablePagination prop to DataTable (default false) and conditionally hide the pagination controls when it's set. Update the pharmacist inventory view to pass disablePagination to the DataTable, remove the "Showing X items" count, and reduce the page LIMIT from 50 to 20 to match the new behavior and layout.