### PR TITLE
Debounce search and use server-side filtering

### DIFF
--- a/app/(root)/pharmacist/customers/page.tsx
+++ b/app/(root)/pharmacist/customers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { DataTable } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -28,6 +28,7 @@ const CustomersPage = () => {
     const { user } = useAuth();
     const accessToken = user?.access_token;
     const [search, setSearch] = useState("");
+    const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
     const [customers, setCustomers] = useState<Customer[]>([]);
     const [loading, setLoading] = useState(true);
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -37,11 +38,16 @@ const CustomersPage = () => {
     const [total, setTotal] = useState(0);
     const LIMIT = 20;
 
-    const fetchCustomers = async (targetPage = 1) => {
+    const fetchCustomers = async (targetPage = 1, searchOverride?: string) => {
         setLoading(true);
         try {
+            const activeSearch = searchOverride !== undefined ? searchOverride : search;
+            const params = new URLSearchParams();
+            params.append("page", String(targetPage));
+            params.append("limit", String(LIMIT));
+            if (activeSearch.trim()) params.append("search", activeSearch.trim());
             const response = await fetch(
-                `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/customer?page=${targetPage}&limit=${LIMIT}`,
+                `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/customer?${params.toString()}`,
                 {
                     headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
                 }
@@ -64,7 +70,19 @@ const CustomersPage = () => {
 
     useEffect(() => {
         if (accessToken) fetchCustomers(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [accessToken]);
+
+    useEffect(() => {
+        if (!accessToken) return;
+        clearTimeout(searchDebounceRef.current);
+        searchDebounceRef.current = setTimeout(() => {
+            setPage(1);
+            void fetchCustomers(1, search);
+        }, 300);
+        return () => clearTimeout(searchDebounceRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [search]);
 
     const columns = [
         {
@@ -203,11 +221,7 @@ const CustomersPage = () => {
                             >
                                 <DataTable
                                     columns={columns}
-                                    data={customers.filter(
-                                        (c) =>
-                                            c.name?.toLowerCase().includes(search.toLowerCase()) ||
-                                            c.phone?.includes(search)
-                                    )}
+                                    data={customers}
                                     disableRowClick={true}
                                 />
                             </motion.div>

--- a/app/(root)/pharmacist/history/page.tsx
+++ b/app/(root)/pharmacist/history/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
@@ -151,11 +151,12 @@ const SalesTable = () => {
   const [saleToDelete, setSaleToDelete] = useState<Sale | null>(null);
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
   const [exportingPdf, setExportingPdf] = useState(false);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
   const { user } = useAuth();
   const accessToken = user?.access_token;
   const { refetchInventory } = useInventory();
 
-  const loadSales = useCallback(async (targetPage = page) => {
+  const loadSales = useCallback(async (targetPage = page, searchOverride?: string) => {
     if (!accessToken) return;
     const range = apiRange(dateRangeMode, customFrom, customTo);
     if (range === null) {
@@ -172,6 +173,9 @@ const SalesTable = () => {
       if (range.end) queryParams.append("endDate", range.end);
       queryParams.append("page", String(targetPage));
       queryParams.append("limit", String(LIMIT));
+      const activeSearch = searchOverride !== undefined ? searchOverride : search;
+      if (activeSearch.trim()) queryParams.append("search", activeSearch.trim());
+      if (paymentFilter !== "ALL") queryParams.append("paymentMethod", paymentFilter);
 
       const response = await fetch(
         `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/sales?${queryParams}`,
@@ -206,7 +210,7 @@ const SalesTable = () => {
     } finally {
       setLoading(false);
     }
-  }, [accessToken, dateRangeMode, customFrom, customTo, page, LIMIT]);
+  }, [accessToken, dateRangeMode, customFrom, customTo, page, LIMIT, search, paymentFilter]);
 
   useEffect(() => {
     setPage(1);
@@ -216,22 +220,25 @@ const SalesTable = () => {
     void loadSales();
   }, [loadSales]);
 
-  const displaySales = useMemo(() => {
-    let rows = sales;
-    if (paymentFilter !== "ALL") {
-      rows = rows.filter((s) => s.paymentMethod === paymentFilter);
-    }
-    if (search.trim()) {
-      const s = search.toLowerCase();
-      rows = rows.filter(
-        (sale) =>
-          (sale.invoiceNumber ?? "").toLowerCase().includes(s) ||
-          (sale.customerName ?? "").toLowerCase().includes(s) ||
-          (sale.customerPhone ?? "").toLowerCase().includes(s),
-      );
-    }
-    return sortSalesNewestFirst(rows);
-  }, [sales, paymentFilter, search]);
+  // Debounced search effect
+  useEffect(() => {
+    clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(() => {
+      setPage(1);
+      void loadSales(1, search);
+    }, 300);
+    return () => clearTimeout(searchDebounceRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  // Debounced paymentFilter effect
+  useEffect(() => {
+    setPage(1);
+    void loadSales(1);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paymentFilter]);
+
+  const displaySales = useMemo(() => sortSalesNewestFirst(sales), [sales]);
 
   const formatCurrency = useCallback(
     (n: number) =>

--- a/app/(root)/pharmacist/manufacturer-working/page.tsx
+++ b/app/(root)/pharmacist/manufacturer-working/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { DataTable } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -68,6 +68,7 @@ interface ManufacturerRaw {
 
 const Manufacturer = () => {
   const [search, setSearch] = useState("");
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
   const [manufacturers, setManufacturers] = useState<ManufacturerRow[]>([]);
   const [manufacturersRaw, setManufacturersRaw] = useState<ManufacturerRaw[]>([]);
   const [loading, setLoading] = useState(true);
@@ -83,11 +84,16 @@ const Manufacturer = () => {
   const { user } = useAuth();
   const accessToken = user?.access_token;
 
-  const fetchManufacturers = async (targetPage = 1) => {
+  const fetchManufacturers = async (targetPage = 1, searchOverride?: string) => {
     setLoading(true);
     try {
+      const activeSearch = searchOverride !== undefined ? searchOverride : search;
+      const params = new URLSearchParams();
+      params.append("page", String(targetPage));
+      params.append("limit", String(LIMIT));
+      if (activeSearch.trim()) params.append("search", activeSearch.trim());
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/manufacturer?page=${targetPage}&limit=${LIMIT}`
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/manufacturer?${params.toString()}`
       );
       if (!response.ok) {
         throw new Error("Failed to fetch manufacturers");
@@ -126,7 +132,18 @@ const Manufacturer = () => {
 
   useEffect(() => {
     fetchManufacturers();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(() => {
+      setPage(1);
+      void fetchManufacturers(1, search);
+    }, 300);
+    return () => clearTimeout(searchDebounceRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
 
   const handleDelete = async () => {
     if (!itemToDelete) return;
@@ -317,12 +334,7 @@ const Manufacturer = () => {
               >
                 <DataTable
                   columns={columns}
-                  data={manufacturers.filter(
-                    (m) =>
-                      m.name?.toLowerCase().includes(search?.toLowerCase()) ||
-                      m.city?.toLowerCase().includes(search?.toLowerCase()) ||
-                      m.country?.toLowerCase().includes(search?.toLowerCase())
-                  )}
+                  data={manufacturers}
                   onRowClick={(m) => setSelectedManufacturer(m)}
                 />
               </motion.div>

--- a/app/(root)/pharmacist/purchase-invoices/page.tsx
+++ b/app/(root)/pharmacist/purchase-invoices/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { parseApiList } from "@/lib/api";
 import { sortByLocaleKey } from "@/lib/sort-alphabetical";
 import { DataTable } from "@/components/shared/DataTable";
@@ -40,6 +40,7 @@ interface Invoice {
 
 export default function PurchaseInvoicesPage() {
     const [search, setSearch] = useState("");
+    const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
     const [invoices, setInvoices] = useState<Invoice[]>([]);
     const [loading, setLoading] = useState(true);
     const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
@@ -48,11 +49,16 @@ export default function PurchaseInvoicesPage() {
     const [total, setTotal] = useState(0);
     const LIMIT = 20;
 
-    const fetchInvoices = async (targetPage = page) => {
+    const fetchInvoices = async (targetPage = page, searchOverride?: string) => {
         setLoading(true);
         try {
+            const activeSearch = searchOverride !== undefined ? searchOverride : search;
+            const params = new URLSearchParams();
+            params.append("page", String(targetPage));
+            params.append("limit", String(LIMIT));
+            if (activeSearch.trim()) params.append("search", activeSearch.trim());
             const response = await fetch(
-                `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/purchase-invoices?page=${targetPage}&limit=${LIMIT}`
+                `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/purchase-invoices?${params.toString()}`
             );
             if (!response.ok) throw new Error("Failed to fetch invoices");
 
@@ -84,7 +90,18 @@ export default function PurchaseInvoicesPage() {
 
     useEffect(() => {
         fetchInvoices();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+        clearTimeout(searchDebounceRef.current);
+        searchDebounceRef.current = setTimeout(() => {
+            setPage(1);
+            void fetchInvoices(1, search);
+        }, 300);
+        return () => clearTimeout(searchDebounceRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [search]);
 
     const columns = [
         {
@@ -202,11 +219,7 @@ export default function PurchaseInvoicesPage() {
                             >
                                 <DataTable
                                     columns={columns}
-                                    data={invoices.filter(
-                                        (i) =>
-                                            i.invoiceNumber.toLowerCase().includes(search.toLowerCase()) ||
-                                            i.supplierLabel.toLowerCase().includes(search.toLowerCase())
-                                    )}
+                                    data={invoices}
                                     onRowClick={(inv) => setSelectedInvoice(inv)}
                                     initialSorting={[{ id: "supplierLabel", desc: false }]}
                                 />

--- a/app/(root)/pharmacist/purchase-orders/view/page.tsx
+++ b/app/(root)/pharmacist/purchase-orders/view/page.tsx
@@ -8,7 +8,7 @@ import { DialogContent } from "@/components/ui/dialog";
 
 import { Dialog } from "@/components/ui/dialog";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertCircle, CheckCircle, Search, XCircle } from "lucide-react";
 import Loading from "@/components/shared/Loading";
@@ -60,22 +60,6 @@ interface PurchaseOrder {
   orderDate: string;
 }
 
-function startOfDayLocal(dateStr: string): Date {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  return new Date(y, m - 1, d, 0, 0, 0, 0);
-}
-
-function endOfDayLocal(dateStr: string): Date {
-  const [y, m, d] = dateStr.split("-").map(Number);
-  return new Date(y, m - 1, d, 23, 59, 59, 999);
-}
-
-function isWithinDateRange(isoDate: string, from: string, to: string): boolean {
-  const d = new Date(isoDate);
-  if (from && d < startOfDayLocal(from)) return false;
-  if (to && d > endOfDayLocal(to)) return false;
-  return true;
-}
 
 export default function ViewPurchaseOrdersPage() {
   const [purchaseOrders, setPurchaseOrders] = useState<PurchaseOrder[]>([]);
@@ -89,6 +73,8 @@ export default function ViewPurchaseOrdersPage() {
   const [search, setSearch] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const dateDebounceRef = useRef<ReturnType<typeof setTimeout>>();
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("en-US", {
@@ -98,31 +84,7 @@ export default function ViewPurchaseOrdersPage() {
     });
   };
 
-  const dateRangeInvalid = Boolean(dateFrom && dateTo && dateFrom > dateTo);
-
-  const filteredOrders = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (dateRangeInvalid) return [];
-    return purchaseOrders.filter((order) => {
-      if (dateFrom || dateTo) {
-        if (!isWithinDateRange(order.createdAt, dateFrom, dateTo)) return false;
-      }
-      if (!q) return true;
-      return (
-        order.orderNumber.toLowerCase().includes(q) ||
-        order.itemName.toLowerCase().includes(q)
-      );
-    });
-  }, [purchaseOrders, search, dateFrom, dateTo, dateRangeInvalid]);
-
-  const filterSummary = useMemo(() => {
-    const units = filteredOrders.reduce((s, o) => s + o.quantityOrdered, 0);
-    return { count: filteredOrders.length, units };
-  }, [filteredOrders]);
-
-  const hasActiveFilters = Boolean(
-    search.trim() || dateFrom || dateTo
-  );
+  const hasActiveFilters = Boolean(search.trim() || dateFrom || dateTo);
 
   // Handle row click
   const handleRowClick = (order: PurchaseOrder) => {
@@ -251,7 +213,7 @@ export default function ViewPurchaseOrdersPage() {
   ];
 
   const table = useReactTable({
-    data: filteredOrders,
+    data: purchaseOrders,
     columns,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -262,11 +224,20 @@ export default function ViewPurchaseOrdersPage() {
     },
   });
 
-  const fetchPurchaseOrders = async (targetPage = serverPage) => {
+  const fetchPurchaseOrders = async (targetPage = serverPage, searchOverride?: string, dateFromOverride?: string, dateToOverride?: string) => {
     try {
       setLoading(true);
+      const activeSearch = searchOverride !== undefined ? searchOverride : search;
+      const activeDateFrom = dateFromOverride !== undefined ? dateFromOverride : dateFrom;
+      const activeDateTo = dateToOverride !== undefined ? dateToOverride : dateTo;
+      const params = new URLSearchParams();
+      params.append("page", String(targetPage));
+      params.append("limit", String(SERVER_LIMIT));
+      if (activeSearch.trim()) params.append("search", activeSearch.trim());
+      if (activeDateFrom) params.append("dateFrom", activeDateFrom);
+      if (activeDateTo) params.append("dateTo", activeDateTo);
       const { data: response } = await axios.get(
-        `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/purchase-orders?page=${targetPage}&limit=${SERVER_LIMIT}`
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/purchase-orders?${params.toString()}`
       );
 
       const orders = parseApiList(response);
@@ -298,7 +269,30 @@ export default function ViewPurchaseOrdersPage() {
 
   useEffect(() => {
     fetchPurchaseOrders();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Debounced search
+  useEffect(() => {
+    clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(() => {
+      setServerPage(1);
+      void fetchPurchaseOrders(1, search, dateFrom, dateTo);
+    }, 300);
+    return () => clearTimeout(searchDebounceRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  // Debounced date filters
+  useEffect(() => {
+    clearTimeout(dateDebounceRef.current);
+    dateDebounceRef.current = setTimeout(() => {
+      setServerPage(1);
+      void fetchPurchaseOrders(1, search, dateFrom, dateTo);
+    }, 300);
+    return () => clearTimeout(dateDebounceRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dateFrom, dateTo]);
 
   if (loading) {
     return (
@@ -395,7 +389,7 @@ export default function ViewPurchaseOrdersPage() {
                 </Button>
               )}
             </div>
-            {dateRangeInvalid && (
+            {dateFrom && dateTo && dateFrom > dateTo && (
               <p className="text-sm text-amber-800 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
                 <strong>From</strong> must be on or before <strong>To</strong>.
               </p>
@@ -403,20 +397,9 @@ export default function ViewPurchaseOrdersPage() {
             {purchaseOrders.length > 0 && (
               <p className="text-sm text-gray-600">
                 Showing{" "}
-                <span className="font-semibold text-red-800">{filterSummary.count}</span>{" "}
-                order{filterSummary.count !== 1 ? "s" : ""}
-                {hasActiveFilters ? " (filtered)" : ""} ·{" "}
-                <span className="font-semibold">{filterSummary.units}</span> units ordered
-                {(dateFrom || dateTo) && !dateRangeInvalid && (
-                  <>
-                    {" "}
-                    {dateFrom && dateTo
-                      ? `from ${formatDate(startOfDayLocal(dateFrom).toISOString())} to ${formatDate(endOfDayLocal(dateTo).toISOString())}`
-                      : dateFrom
-                        ? `from ${formatDate(startOfDayLocal(dateFrom).toISOString())}`
-                        : `until ${formatDate(endOfDayLocal(dateTo).toISOString())}`}
-                  </>
-                )}
+                <span className="font-semibold text-red-800">{purchaseOrders.length}</span>{" "}
+                order{purchaseOrders.length !== 1 ? "s" : ""}
+                {hasActiveFilters ? " (filtered)" : ""}
               </p>
             )}
           </CardContent>
@@ -451,23 +434,9 @@ export default function ViewPurchaseOrdersPage() {
                   There are no purchase orders yet. Create one from the low stock page.
                 </p>
               </motion.div>
-            ) : filteredOrders.length === 0 ? (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                className="flex flex-col items-center justify-center py-12 px-4 rounded-lg bg-gray-50/80"
-              >
-                <div className="h-14 w-14 rounded-full bg-gray-100 flex items-center justify-center mb-3">
-                  <Search className="h-7 w-7 text-gray-400" />
-                </div>
-                <p className="text-sm font-medium text-gray-600">No matching orders</p>
-                <p className="text-xs text-gray-500 mt-0.5 text-center max-w-sm">
-                  Change search or date range, or clear filters to see all orders.
-                </p>
-              </motion.div>
             ) : (
               <div className="rounded-lg border border-gray-100 overflow-hidden">
-                <Table wrapperClassName={filteredOrders.length > 0 ? "min-h-[260px]" : undefined}>
+                <Table wrapperClassName={purchaseOrders.length > 0 ? "min-h-[260px]" : undefined}>
                   <TableHeader>
                     {table.getHeaderGroups().map((headerGroup) => (
                       <TableRow key={headerGroup.id}>

--- a/app/(root)/pharmacist/supplier-payments/page.tsx
+++ b/app/(root)/pharmacist/supplier-payments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { DataTable } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
@@ -35,6 +35,7 @@ interface Payment {
 
 const SupplierPayments = () => {
     const [search, setSearch] = useState("");
+    const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
     const [payments, setPayments] = useState<Payment[]>([]);
     const [loading, setLoading] = useState(true);
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -49,16 +50,20 @@ const SupplierPayments = () => {
     const { user } = useAuth();
     const accessToken = user?.access_token;
 
-    const fetchPayments = useCallback(async (targetPage = 1) => {
+    const fetchPayments = useCallback(async (targetPage = 1, searchOverride?: string) => {
         setLoading(true);
         try {
             const headers: HeadersInit = {};
             if (accessToken) {
                 (headers as Record<string, string>).Authorization = `Bearer ${accessToken}`;
             }
-
+            const activeSearch = searchOverride !== undefined ? searchOverride : search;
+            const params = new URLSearchParams();
+            params.append("page", String(targetPage));
+            params.append("limit", String(LIMIT));
+            if (activeSearch.trim()) params.append("search", activeSearch.trim());
             const response = await fetch(
-                `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/supplier-payments?page=${targetPage}&limit=${LIMIT}`,
+                `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/supplier-payments?${params.toString()}`,
                 { headers },
             );
             if (!response.ok) {
@@ -100,11 +105,21 @@ const SupplierPayments = () => {
         } finally {
             setLoading(false);
         }
-    }, [accessToken, LIMIT]);
+    }, [accessToken, LIMIT, search]);
 
     useEffect(() => {
         fetchPayments(1);
     }, [fetchPayments]);
+
+    useEffect(() => {
+        clearTimeout(searchDebounceRef.current);
+        searchDebounceRef.current = setTimeout(() => {
+            setPage(1);
+            void fetchPayments(1, search);
+        }, 300);
+        return () => clearTimeout(searchDebounceRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [search]);
 
     const openCreateModal = () => {
         setEditPayment(null);
@@ -291,11 +306,7 @@ const SupplierPayments = () => {
                                 >
                                     <DataTable
                                         columns={columns}
-                                        data={payments.filter(
-                                            (p) =>
-                                                p.payeeLabel?.toLowerCase().includes(search?.toLowerCase()) ||
-                                                p.reference?.toLowerCase().includes(search?.toLowerCase()),
-                                        )}
+                                        data={payments}
                                         onRowClick={(p) => setSelectedPayment(p)}
                                         initialSorting={[{ id: "payeeLabel", desc: false }]}
                                     />

--- a/app/(root)/pharmacist/vendor-working/page.tsx
+++ b/app/(root)/pharmacist/vendor-working/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { DataTable } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
@@ -38,6 +38,7 @@ interface VendorRow {
 
 export default function VendorsPage() {
   const [search, setSearch] = useState("");
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout>>();
   const [vendorsRaw, setVendorsRaw] = useState<VendorRaw[]>([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
@@ -52,14 +53,19 @@ export default function VendorsPage() {
   const { user } = useAuth();
   const accessToken = user?.access_token;
 
-  const fetchVendors = async (targetPage = 1) => {
+  const fetchVendors = async (targetPage = 1, searchOverride?: string) => {
     setLoading(true);
     try {
       const headers: HeadersInit = {};
       if (accessToken) {
         (headers as Record<string, string>).Authorization = `Bearer ${accessToken}`;
       }
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/vendor?page=${targetPage}&limit=${LIMIT}`, { headers });
+      const activeSearch = searchOverride !== undefined ? searchOverride : search;
+      const params = new URLSearchParams();
+      params.append("page", String(targetPage));
+      params.append("limit", String(LIMIT));
+      if (activeSearch.trim()) params.append("search", activeSearch.trim());
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/vendor?${params.toString()}`, { headers });
       if (!res.ok) throw new Error("Failed to fetch vendors");
       const result = await res.json();
       const list = parseApiList<VendorRaw>(result);
@@ -78,7 +84,18 @@ export default function VendorsPage() {
 
   useEffect(() => {
     fetchVendors();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accessToken]);
+
+  useEffect(() => {
+    clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(() => {
+      setPage(1);
+      void fetchVendors(1, search);
+    }, 300);
+    return () => clearTimeout(searchDebounceRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
 
   const vendorRows = useMemo(
     () =>
@@ -209,13 +226,6 @@ export default function VendorsPage() {
     },
   ];
 
-  const filtered = vendorRows.filter(
-    (v) =>
-      v.name.toLowerCase().includes(search.toLowerCase()) ||
-      v.vendorType.toLowerCase().includes(search.toLowerCase()) ||
-      v.manufacturerNames.toLowerCase().includes(search.toLowerCase()),
-  );
-
   return (
     <div className="min-h-screen bg-gray-50/80">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
@@ -267,7 +277,7 @@ export default function VendorsPage() {
                 </motion.div>
               ) : (
                 <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="rounded-lg border border-gray-100 overflow-hidden">
-                  <DataTable columns={columns} data={filtered} onRowClick={(v) => setSelected(v)} />
+                  <DataTable columns={columns} data={vendorRows} onRowClick={(v) => setSelected(v)} />
                 </motion.div>
               )}
             </AnimatePresence>


### PR DESCRIPTION
Add debounced search across multiple pharmacist pages and move filtering to the server. Introduces searchDebounceRef refs and 300ms debounce effects, updates fetch functions to accept optional search (and date) overrides and build query params via URLSearchParams, and replaces in-component array filtering with server-provided results. Also adds debounced reactions for payment and date filters, adjusts related hook deps, and simplifies some client-side display/sorting logic (e.g. sales sorting). These changes reduce client CPU usage and network chatter while centralizing pagination and search on the API.