### PR TITLE
Pharmacy: sale shortcut, report range, WhatsApp

### DIFF
--- a/app/(root)/pharmacist/customers/page.tsx
+++ b/app/(root)/pharmacist/customers/page.tsx
@@ -13,6 +13,7 @@ import { PaginationControls } from "@/components/shared/PaginationControls";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/app/providers/AuthProvider";
 import { parseApiList } from "@/lib/api";
+import { ShoppingCart } from "lucide-react";
 
 interface Customer {
     id: string;
@@ -109,6 +110,29 @@ const CustomersPage = () => {
             accessorKey: "email",
             header: "Email Address",
             cell: ({ row }: any) => <span>{row.original.email || "-"}</span>,
+        },
+        {
+            id: "startSale",
+            header: "Sale",
+            enableSorting: false,
+            cell: ({ row }: any) => (
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-red-700 hover:text-red-900 hover:bg-red-50"
+                    onClick={() => {
+                        const c = row.original;
+                        const params = new URLSearchParams();
+                        if (c.id) params.set("customerId", c.id);
+                        if (c.name) params.set("name", c.name);
+                        if (c.phone) params.set("phone", c.phone);
+                        router.push(`/pharmacist/sales?${params.toString()}`);
+                    }}
+                >
+                    <ShoppingCart className="h-4 w-4 mr-1" />
+                    Sale
+                </Button>
+            ),
         },
         {
             accessorKey: "creditBalance",

--- a/app/(root)/pharmacist/page.tsx
+++ b/app/(root)/pharmacist/page.tsx
@@ -44,7 +44,7 @@ function getMonthRange(monthOffset: number) {
 
 const PharmacistPage = () => {
   const {
-    state: { items },
+    state: { items, inventoryTotal },
     getLowStockItems,
     getExpiringItems,
   } = useInventory();
@@ -255,7 +255,7 @@ const PharmacistPage = () => {
         </header>
 
         <PharmacyStats
-          items={items}
+          totalItems={inventoryTotal || items.length}
           lowStockCount={lowStockCount}
           expiringCount={expiringCount}
           earnedThisMonth={earnedThisMonth}

--- a/app/(root)/pharmacist/pharmacy-stats.tsx
+++ b/app/(root)/pharmacist/pharmacy-stats.tsx
@@ -142,13 +142,13 @@ function formatCurrency(amount: number) {
 }
 
 export default function PharmacyStats({
-  items,
+  totalItems,
   lowStockCount,
   expiringCount,
   earnedThisMonth = 0,
   earnedLastMonth = 0,
 }: {
-  items: any[];
+  totalItems: number;
   lowStockCount: number;
   expiringCount: number;
   earnedThisMonth?: number;
@@ -164,7 +164,7 @@ export default function PharmacyStats({
     {
       index: 0,
       title: "Total Items",
-      value: items.length,
+      value: totalItems,
       change: { value: 4.63, trend: "up" },
       icon: Package,
       accent: "red",

--- a/app/(root)/pharmacist/reports/profit-loss/page.tsx
+++ b/app/(root)/pharmacist/reports/profit-loss/page.tsx
@@ -6,9 +6,12 @@ import { motion } from "framer-motion";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import Loading from "@/components/shared/Loading";
 
 type Period = "day" | "month" | "year";
+type RangeMode = "period" | "custom";
 
 interface PersonalExpensesSummary {
   totalDebit: number;
@@ -33,14 +36,29 @@ export default function ProfitLossReportPage() {
   const [data, setData] = useState<ProfitLossData | null>(null);
   const [loading, setLoading] = useState(true);
   const [period, setPeriod] = useState<Period>("month");
+  const [rangeMode, setRangeMode] = useState<RangeMode>("period");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+
+  const customIncomplete = rangeMode === "custom" && (!customFrom || !customTo);
 
   useEffect(() => {
     if (!user?.access_token) return;
+    if (customIncomplete) { setData(null); setLoading(false); return; }
+
     const fetchData = async () => {
       setLoading(true);
       try {
+        const params = new URLSearchParams();
+        if (rangeMode === "custom" && customFrom && customTo) {
+          params.set("from", customFrom);
+          params.set("to", customTo);
+          params.set("period", "day");
+        } else {
+          params.set("period", period);
+        }
         const res = await fetch(
-          `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/reports/profit-loss?period=${period}`,
+          `${process.env.NEXT_PUBLIC_API_BASE_URL}/pharmacist/reports/profit-loss?${params}`,
           { headers: { Authorization: `Bearer ${user.access_token}` } }
         );
         const json = await res.json();
@@ -52,7 +70,7 @@ export default function ProfitLossReportPage() {
       }
     };
     fetchData();
-  }, [user?.access_token, period]);
+  }, [user?.access_token, period, rangeMode, customFrom, customTo, customIncomplete]);
 
   const formatCurrency = (n: number) =>
     new Intl.NumberFormat("en-PK", {
@@ -61,9 +79,12 @@ export default function ProfitLossReportPage() {
       maximumFractionDigits: 0,
     }).format(n);
 
-  const gross =
-    data?.grossProfit ?? (data ? data.totalRevenue - data.totalCost : 0);
+  const gross = data?.grossProfit ?? (data ? data.totalRevenue - data.totalCost : 0);
   const expenses = data?.personalExpenses;
+
+  const dateLabel = data
+    ? `${new Date(data.from).toLocaleDateString("en-GB")} – ${new Date(data.to).toLocaleDateString("en-GB")}`
+    : null;
 
   return (
     <div className="min-h-screen bg-gray-50/80">
@@ -102,32 +123,104 @@ export default function ProfitLossReportPage() {
         </header>
 
         <Card className="overflow-hidden bg-white border border-gray-100 rounded-xl shadow-sm hover:shadow-md transition-shadow">
-          <div className="border-l-4 border-l-red-500 bg-red-50/30 px-5 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-            <div>
-              <h2 className="text-base font-semibold text-red-800">Financial Summary</h2>
-              <p className="text-xs text-gray-500 mt-0.5">Select a period to filter results</p>
+          <div className="border-l-4 border-l-red-500 bg-red-50/30 px-5 py-4">
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+              <div>
+                <h2 className="text-base font-semibold text-red-800">Financial Summary</h2>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  {dateLabel ?? "Select a period to filter results"}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2 items-center">
+                {/* Mode toggle */}
+                <div className="flex bg-white p-1 rounded-lg border border-gray-100 shadow-sm">
+                  <Button
+                    variant={rangeMode === "period" ? "default" : "ghost"}
+                    size="sm"
+                    onClick={() => setRangeMode("period")}
+                    className={rangeMode === "period" ? "bg-red-800 text-white hover:bg-red-700 px-3" : "text-gray-600 hover:text-red-800 hover:bg-red-50 px-3"}
+                  >
+                    Period
+                  </Button>
+                  <Button
+                    variant={rangeMode === "custom" ? "default" : "ghost"}
+                    size="sm"
+                    onClick={() => setRangeMode("custom")}
+                    className={rangeMode === "custom" ? "bg-red-800 text-white hover:bg-red-700 px-3" : "text-gray-600 hover:text-red-800 hover:bg-red-50 px-3"}
+                  >
+                    Custom
+                  </Button>
+                </div>
+
+                {/* Period buttons (shown when mode=period) */}
+                {rangeMode === "period" && (
+                  <div className="flex bg-white p-1 rounded-lg border border-gray-100 shadow-sm">
+                    {(["day", "month", "year"] as const).map((p) => (
+                      <Button
+                        key={p}
+                        variant={period === p ? "default" : "ghost"}
+                        size="sm"
+                        onClick={() => setPeriod(p)}
+                        className={`capitalize px-4 ${period === p ? "bg-red-800 text-white hover:bg-red-700" : "text-gray-600 hover:text-red-800 hover:bg-red-50"}`}
+                      >
+                        {p}
+                      </Button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
-            <div className="flex bg-white p-1 rounded-lg border border-gray-100 shadow-sm">
-              {(["day", "month", "year"] as const).map((p) => (
-                <Button
-                  key={p}
-                  variant={period === p ? "default" : "ghost"}
-                  size="sm"
-                  onClick={() => setPeriod(p)}
-                  className={`capitalize px-4 ${period === p ? "bg-red-800 text-white hover:bg-red-700" : "text-gray-600 hover:text-red-800 hover:bg-red-50"
-                    }`}
-                >
-                  {p}
-                </Button>
-              ))}
-            </div>
+
+            {/* Custom date inputs */}
+            {rangeMode === "custom" && (
+              <div className="flex flex-wrap items-end gap-4 mt-4">
+                <div>
+                  <Label className="text-xs text-gray-600">From</Label>
+                  <Input
+                    type="date"
+                    value={customFrom}
+                    onChange={(e) => setCustomFrom(e.target.value)}
+                    className="mt-1 w-[160px] border border-gray-300 bg-white shadow-sm"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs text-gray-600">To</Label>
+                  <Input
+                    type="date"
+                    value={customTo}
+                    onChange={(e) => setCustomTo(e.target.value)}
+                    className="mt-1 w-[160px] border border-gray-300 bg-white shadow-sm"
+                  />
+                </div>
+                {(customFrom || customTo) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-gray-200 text-gray-600"
+                    onClick={() => { setCustomFrom(""); setCustomTo(""); }}
+                  >
+                    Clear
+                  </Button>
+                )}
+                {customIncomplete && (
+                  <p className="text-sm text-amber-800 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
+                    Select both <strong>From</strong> and <strong>To</strong> dates.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
+
           <CardContent className="p-6">
             {loading ? (
               <div className="py-20 flex items-center justify-center">
                 <Loading />
               </div>
-            ) : data ? (
+            ) : !data ? (
+              <div className="py-20 text-center">
+                <p className="text-gray-500 font-medium">Select a date range to view the report.</p>
+              </div>
+            ) : (
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
@@ -135,52 +228,35 @@ export default function ProfitLossReportPage() {
               >
                 <div className="rounded-xl border border-green-100 bg-green-50/20 p-5">
                   <p className="text-sm font-medium text-green-700 mb-1">Total Revenue</p>
-                  <p className="text-2xl font-bold text-green-600">
-                    {formatCurrency(data.totalRevenue)}
-                  </p>
+                  <p className="text-2xl font-bold text-green-600">{formatCurrency(data.totalRevenue)}</p>
                 </div>
                 <div className="rounded-xl border border-amber-100 bg-amber-50/20 p-5">
                   <p className="text-sm font-medium text-amber-700 mb-1">Total Cost (COGS)</p>
-                  <p className="text-2xl font-bold text-amber-600">
-                    {formatCurrency(data.totalCost)}
-                  </p>
+                  <p className="text-2xl font-bold text-amber-600">{formatCurrency(data.totalCost)}</p>
                 </div>
                 <div className="rounded-xl border border-sky-100 bg-sky-50/20 p-5">
                   <p className="text-sm font-medium text-sky-700 mb-1">Gross Profit</p>
-                  <p className="text-2xl font-bold text-sky-600">
-                    {formatCurrency(gross)}
-                  </p>
+                  <p className="text-2xl font-bold text-sky-600">{formatCurrency(gross)}</p>
                 </div>
                 <div className="rounded-xl border border-rose-100 bg-rose-50/20 p-5">
                   <p className="text-sm font-medium text-rose-700 mb-1">Personal Expenses</p>
-                  <p className="text-2xl font-bold text-rose-600">
-                    {formatCurrency(expenses?.net ?? 0)}
-                  </p>
+                  <p className="text-2xl font-bold text-rose-600">{formatCurrency(expenses?.net ?? 0)}</p>
                   {expenses && expenses.count > 0 && (
                     <p className="text-xs text-gray-500 mt-1">
-                      {expenses.count} entries · Dr {formatCurrency(expenses.totalDebit)} · Cr{" "}
-                      {formatCurrency(expenses.totalCredit)}
+                      {expenses.count} entries · Dr {formatCurrency(expenses.totalDebit)} · Cr {formatCurrency(expenses.totalCredit)}
                     </p>
                   )}
                 </div>
-                <div className={`rounded-xl border p-5 sm:col-span-2 lg:col-span-1 ${data.profit >= 0
-                  ? "border-green-100 bg-green-50/20"
-                  : "border-red-100 bg-red-50/20"
-                  }`}>
+                <div className={`rounded-xl border p-5 sm:col-span-2 lg:col-span-1 ${data.profit >= 0 ? "border-green-100 bg-green-50/20" : "border-red-100 bg-red-50/20"}`}>
                   <p className={`text-sm font-medium mb-1 ${data.profit >= 0 ? "text-green-700" : "text-red-700"}`}>
                     Net Profit
                   </p>
-                  <p className={`text-2xl font-bold ${data.profit >= 0 ? "text-green-600" : "text-red-600"
-                    }`}>
+                  <p className={`text-2xl font-bold ${data.profit >= 0 ? "text-green-600" : "text-red-600"}`}>
                     {formatCurrency(data.profit)}
                   </p>
                   <p className="text-xs text-gray-500 mt-1">After COGS and personal expenses</p>
                 </div>
               </motion.div>
-            ) : (
-              <div className="py-20 text-center">
-                <p className="text-gray-500 font-medium">No financial data available for this period.</p>
-              </div>
             )}
           </CardContent>
         </Card>

--- a/app/(root)/pharmacist/sales/page.tsx
+++ b/app/(root)/pharmacist/sales/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -26,6 +27,7 @@ import {
   ScanLine,
   Syringe,
   Droplet,
+  MessageCircle,
 } from "lucide-react";
 
 import { toast } from "sonner";
@@ -54,7 +56,8 @@ interface CartItem extends Product {
   quantity: number;
 }
 
-const SalesPage = () => {
+const SalesPageInner = () => {
+  const searchParams = useSearchParams();
   const [searchTerm, setSearchTerm] = useState("");
   const [products, setProducts] = useState<Product[]>([]);
   const [productCache, setProductCache] = useState<Map<string, Product>>(new Map());
@@ -67,9 +70,9 @@ const SalesPage = () => {
   const [isReceiptModalOpen, setIsReceiptModalOpen] = useState(false);
   const [discount, setDiscount] = useState<string>("");
   const [barcodeInput, setBarcodeInput] = useState("");
-  const [customerName, setCustomerName] = useState("");
-  const [customerPhone, setCustomerPhone] = useState("");
-  const [customerId, setCustomerId] = useState<string | undefined>();
+  const [customerName, setCustomerName] = useState(() => searchParams.get("name") ?? "");
+  const [customerPhone, setCustomerPhone] = useState(() => searchParams.get("phone") ?? "");
+  const [customerId, setCustomerId] = useState<string | undefined>(() => searchParams.get("customerId") ?? undefined);
   const [paymentMethod, setPaymentMethod] = useState<"CASH" | "CARD" | "ONLINE" | "DONATION" | "CREDIT">("CASH");
   const [completedSale, setCompletedSale] = useState<{ invoiceNumber: string; paymentMethod: string } | null>(null);
   const [isStockErrorOpen, setIsStockErrorOpen] = useState(false);
@@ -221,7 +224,7 @@ const SalesPage = () => {
         );
       }
 
-      return [...prevCart, { ...currentProductData, quantity }];
+      return [{ ...currentProductData, quantity }, ...prevCart];
     });
   };
 
@@ -336,6 +339,29 @@ const SalesPage = () => {
     setCompletedSale(null);
     setIsReceiptModalOpen(false);
     focusBarcodeInput();
+  };
+
+  const sendWhatsApp = () => {
+    if (!customerPhone || !completedSale) return;
+    const phone = customerPhone.replace(/\D/g, "").replace(/^0/, "92");
+    const date = new Date().toLocaleDateString("en-GB");
+    const lines = cart.map(
+      (i) => `• ${i.name} × ${i.quantity} = Rs ${(i.price * i.quantity).toFixed(0)}`
+    ).join("\n");
+    const message = [
+      `NS Ibrahim Medical`,
+      `Invoice #${completedSale.invoiceNumber} | ${date}`,
+      customerName ? `Patient: ${customerName}` : null,
+      ``,
+      lines,
+      ``,
+      discountPercent > 0 ? `Discount: ${discountPercent}%` : null,
+      `Net Bill: Rs ${discountedTotal.toFixed(0)}`,
+      `Payment: ${completedSale.paymentMethod}`,
+      ``,
+      `Thank you for visiting NS Ibrahim Medical!`,
+    ].filter(Boolean).join("\n");
+    window.open(`https://wa.me/${phone}?text=${encodeURIComponent(message)}`, "_blank");
   };
 
   const handlePrint = useReactToPrint({
@@ -810,10 +836,26 @@ const SalesPage = () => {
                   {isProcessing ? "Processing..." : "Proceed to Checkout"}
                 </Button>
               ) : (
-                <Button onClick={handlePrint} className="bg-red-800 hover:bg-red-800/80">
-                  <Printer className="mr-2 h-4 w-4" />
-                  Print Bill
-                </Button>
+                <>
+                  {customerPhone && (
+                    <Button
+                      onClick={sendWhatsApp}
+                      className="text-white font-medium"
+                      style={{ backgroundColor: "#25D366" }}
+                      onMouseEnter={e => (e.currentTarget.style.backgroundColor = "#1da851")}
+                      onMouseLeave={e => (e.currentTarget.style.backgroundColor = "#25D366")}
+                    >
+                      <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
+                      </svg>
+                      Send to WhatsApp
+                    </Button>
+                  )}
+                  <Button onClick={handlePrint} className="bg-red-800 hover:bg-red-800/80">
+                    <Printer className="mr-2 h-4 w-4" />
+                    Print Bill
+                  </Button>
+                </>
               )}
             </DialogFooter>
           </DialogContent>
@@ -853,6 +895,12 @@ const SalesPage = () => {
     </div>
   );
 };
+
+const SalesPage = () => (
+  <Suspense>
+    <SalesPageInner />
+  </Suspense>
+);
 
 export default SalesPage;
 

--- a/app/context/InventoryContext.tsx
+++ b/app/context/InventoryContext.tsx
@@ -49,16 +49,19 @@ export interface InventoryItem {
 
 interface InventoryState {
   items: InventoryItem[];
+  inventoryTotal: number;
 }
 
 type InventoryAction =
   | { type: "ADD_ITEM"; payload: InventoryItem }
   | { type: "UPDATE_ITEM"; payload: InventoryItem }
   | { type: "DELETE_ITEM"; payload: string }
-  | { type: "SET_ITEMS"; payload: InventoryItem[] };
+  | { type: "SET_ITEMS"; payload: InventoryItem[] }
+  | { type: "SET_INVENTORY_TOTAL"; payload: number };
 
 const initialState: InventoryState = {
   items: [],
+  inventoryTotal: 0,
 };
 
 export interface PaginationMeta {
@@ -122,6 +125,8 @@ const inventoryReducer = (
         ...state,
         items: sortByLocaleKey(action.payload, (i) => i.name),
       };
+    case "SET_INVENTORY_TOTAL":
+      return { ...state, inventoryTotal: action.payload };
     default:
       return state;
   }
@@ -146,10 +151,10 @@ export const InventoryProvider = ({
         },
       }
     );
-    dispatch({
-      type: "SET_ITEMS",
-      payload: parseApiList<InventoryItem>(response.data),
-    });
+    dispatch({ type: "SET_ITEMS", payload: parseApiList<InventoryItem>(response.data) });
+    if (response.data?.meta?.total != null) {
+      dispatch({ type: "SET_INVENTORY_TOTAL", payload: response.data.meta.total });
+    }
   }, [accessToken]);
 
   const addItem = async (


### PR DESCRIPTION
Add quick-sale action and improve reporting and sales flows. Customers table now includes a Sale button that navigates to the sales page with customer params. Profit/Loss report gains a period/custom range mode with date inputs, validation, and updated fetch params and UI states. Sales page reads URL search params to prefill customer info, prepends added items to the cart, adds a Send to WhatsApp action for completed invoices, and wraps the page in Suspense. Inventory context now tracks inventoryTotal (from API meta.total) and exposes it to PharmacyStats, which was updated to accept totalItems instead of items.